### PR TITLE
Encoding issue 

### DIFF
--- a/html_filters.rb
+++ b/html_filters.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'rubygems'
 require 'nokogiri'
 
@@ -5,7 +6,7 @@ module Liquid
   module StandardFilters
     
     def truncatehtml(raw, max_length = 15, continuation_string = "...")
-      doc = Nokogiri::HTML(raw)
+     doc = Nokogiri::HTML(Iconv.conv('ASCII//TRANSLIT//IGNORE', 'UTF8', raw)) 
       current_length = 0;
       deleting = false
       to_delete = []


### PR DESCRIPTION
So I noticed that some characters like apostrophes were being converted to a bunch of weird characters. This was an issue with encoding, and I think it might be related to the transition to Ruby 1.9. 

Anyways, I added in two lines to convert all the ASCII encoding to UTF-8 so nokogiri works correctly.
