### PR TITLE
Added 'iconv' gem require

### DIFF
--- a/html_filters.rb
+++ b/html_filters.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require 'rubygems'
 require 'nokogiri'
+require "iconv"
 
 module Liquid
   module StandardFilters


### PR DESCRIPTION
Just add a line:
   require 'icon'

because of projects like 'jekyll' don't include this gem in a nutshell
