### PR TITLE
Ruby 1.9 support

### DIFF
--- a/html_filters.rb
+++ b/html_filters.rb
@@ -6,7 +6,7 @@ module Liquid
   module StandardFilters
     
     def truncatehtml(raw, max_length = 15, continuation_string = "...")
-     doc = Nokogiri::HTML(Iconv.conv('UTF8//TRANSLIT//IGNORE', 'UTF8', raw)) 
+     doc = Nokogiri::HTML(raw.encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '')) 
       current_length = 0;
       deleting = false
       to_delete = []


### PR DESCRIPTION
First I want to say: awesome plugin, thanks for writing it!

I tried using it with ruby 1.9 but got errors related to Iconv. With all the encoding related changes in 1.9 it turns out the recommended way to do this [has changed](http://stackoverflow.com/questions/8148762/iconv-deprecation-warning-with-ruby-1-9-3/11287648#11287648).

The [other answer linked inside](http://stackoverflow.com/questions/7870636/equivalent-of-iconv-convutf-8-ignore-in-ruby-1-9-x/7870859#7870859) does express some concerns that string.encode does not work exactly like iconv, but the guy who wrote string.encode says that [the differences should be small enough that you probably don't need to worry about it](http://www.ruby-forum.com/topic/993446).

Anyway, I tested the change on my own jekyll site and everything seemed to work okay.
