### PR TITLE
Fix plugin to produce valid HTML

### DIFF
--- a/html_filters.rb
+++ b/html_filters.rb
@@ -7,7 +7,7 @@ module Jekyll
   module TruncateHTMLFilter
     
     def truncatehtml(raw, max_length = 15, continuation_string = "...")
-     doc = Nokogiri::HTML(raw.encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '')) 
+     doc = Nokogiri::HTML.fragment(raw.encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => ''))
       current_length = 0;
       deleting = false
       to_delete = []


### PR DESCRIPTION
Nokogiri was adding `<html><body>...` to anything filtered through `truncatehtml`. This produced very invalid html.

I switched it to use the [fragment](http://nokogiri.org/Nokogiri/HTML.html) method so that Nokogiri doesn't add these extra tags.
