### PR TITLE
Fix length truncation math

### DIFF
--- a/html_filters.rb
+++ b/html_filters.rb
@@ -25,7 +25,7 @@ module Jekyll
         if !deleting && current_length > max_length
           deleting = true
           
-          trim_to_length = current_length - max_length + 1
+          trim_to_length = node.text.length - (current_length - max_length) - 1
           node.content = node.text[0..trim_to_length] + continuation_string
         end
       end


### PR DESCRIPTION
This sets the length incorrectly in nearly all cases:

Case 1: Only 1 HTML element that exceeds max_length
e.g. length=500 when max_length=150. trim_to_length will be set to 351.
It should be set to 150. (really 149 for 0-index)

Case 2: Multiple elements, last element's length will also be wrong.
e.g. already 50 chars, next length=300, max_length=150. trim_to_length will be set to 201
It should be set to 100 (really 99 for 0-index)